### PR TITLE
Fix incompatible with crate bincode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "binread"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,9 +472,10 @@ dependencies = [
 
 [[package]]
 name = "ree-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
+ "bincode",
  "bitcoin",
  "candid",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ree-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 homepage = "https://www.omnity.network/"
@@ -22,3 +22,6 @@ serde = { version = "1.0", features = ["derive"] }
 hex = "0.4"
 bitcoin = { version = "0.32", default-features = false, features = ["base64", "serde"] }
 ciborium = "0.2"
+
+[dev-dependencies]
+bincode = "1.3"

--- a/src/pubkey.rs
+++ b/src/pubkey.rs
@@ -116,7 +116,7 @@ impl<'de> serde::Deserialize<'de> for Pubkey {
     where
         D: serde::de::Deserializer<'de>,
     {
-        deserializer.deserialize_any(PubkeyVisitor)
+        deserializer.deserialize_str(PubkeyVisitor)
     }
 }
 
@@ -126,5 +126,24 @@ impl serde::Serialize for Pubkey {
         S: serde::ser::Serializer,
     {
         serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bincode_serde() {
+        let pubkey_hex = "007c06bc45a24f098e327b1e27ed5a9b4477b58c3bbfed5a3bb36c6f59bda290b2";
+        let pubkey_bytes = hex::decode(pubkey_hex).unwrap();
+        let pubkey = Pubkey(pubkey_bytes);
+        let encoded_hex = hex::encode(bincode::serialize(&pubkey).unwrap());
+        assert_eq!(
+            pubkey.0,
+            bincode::deserialize::<Pubkey>(&hex::decode(encoded_hex).unwrap())
+                .unwrap()
+                .0
+        );
     }
 }


### PR DESCRIPTION
While using v0.1.0 implementation, the serialized bytes of type CoinId, Pubkey and Txid with crate `bincode`, can NOT be deserialize by `bincode` itself (because `bincode` doesn't support `deserialize_any`).

This pr has implemented a compatible version of these types for this issue.